### PR TITLE
Fix docs build: bump Sphinx from 3.0.3 to >=7

### DIFF
--- a/docs_src/requirements.txt
+++ b/docs_src/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==3.0.3
-sphinx_book_theme
+sphinx>=7.0.0,<10.0.0
+sphinx_book_theme>=1.1.0


### PR DESCRIPTION
zmq's `docs_src/requirements.txt` pinned `sphinx==3.0.3`, which imports `pkg_resources` (removed from modern setuptools) and crashes the docs workflow with `ModuleNotFoundError: No module named 'pkg_resources'`. Bumps to `sphinx>=7.0.0,<10.0.0` + `sphinx_book_theme>=1.1.0`, matching the other packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)